### PR TITLE
[13.0] [FIX] Fix AttributeOptionWizard error

### DIFF
--- a/attribute_set/wizard/attribute_option_wizard.py
+++ b/attribute_set/wizard/attribute_option_wizard.py
@@ -22,6 +22,7 @@ class AttributeOptionWizard(models.TransientModel):
         default=lambda self: self.env.context.get("attribute_id", False),
         ondelete="cascade",
     )
+    option_ids = fields.Boolean()
 
     def validate(self):
         return True
@@ -44,7 +45,7 @@ class AttributeOptionWizard(models.TransientModel):
                     "value_ref": "{},{}".format(attr.relation_model_id.model, op_id),
                 }
             )
-
+        vals['option_ids'] = False
         res = super().create(vals)
 
         return res


### PR DESCRIPTION
When odoo tries to create the AttributeOptionWizard record, error occurs because option_ids field missing in the AttributeOptionWizard model
This fix that by create a option_ids field just to make create method work.
It is not a perfect solution, but because AttributeOptionWizard is an TransientModel and it will be vacuum cleaned, it's not make a big difference. 